### PR TITLE
Guard against null promise in the activity listener

### DIFF
--- a/android/src/main/java/com/anttivuor/rnstartactivityforresult/RNStartActivityForResultModule.java
+++ b/android/src/main/java/com/anttivuor/rnstartactivityforresult/RNStartActivityForResultModule.java
@@ -82,7 +82,7 @@ public class RNStartActivityForResultModule extends ReactContextBaseJavaModule {
     private final ActivityEventListener mActivityEventListener = new BaseActivityEventListener() {
         @Override
         public void onActivityResult(Activity activity, int requestCode, int resultCode, Intent data) {
-            if (data != null) {
+            if (mPromise != null && data != null) {
                 String returnValue = data.getStringExtra(returnKey);
                 mPromise.resolve(returnValue);
                 mPromise = null;


### PR DESCRIPTION
If an app starts a different activity *before* using `startActivityForResult`, then we fail with a NPE due to the fact, that the `mPromise` is not yet initialized as the activity listener is registered before even calling the `startActivityForResult`. A more proper fix would be to probably try and register the activity listener only after the call but this patch tries to at least prevent the crash from happening.